### PR TITLE
PHP 8.2 Deprecation fixes

### DIFF
--- a/library/ZendX/JQuery/View/Helper/JQuery.php
+++ b/library/ZendX/JQuery/View/Helper/JQuery.php
@@ -56,6 +56,11 @@ class ZendX_JQuery_View_Helper_JQuery extends Zend_View_Helper_Abstract
      */
     public $view;
 
+    /**
+     * @var ZendX_JQuery_View_Helper_JQuery_Container
+     */
+    private $_container;
+
 	/**
 	 * jQuery no Conflict Mode
 	 *


### PR DESCRIPTION
This fixes a minor deprecation in PHP 8.2:

`Creation of dynamic property ZendX_JQuery_View_Helper_JQuery::$_container is deprecated`